### PR TITLE
staff: fix broken image links

### DIFF
--- a/staff/index.md
+++ b/staff/index.md
@@ -28,12 +28,14 @@ h6 {
 </style>
 <!-- for staff_member in site.data.staff -->
 {% for staff_member in site.data.staff %}
+<div class="col span_3 center staff-nav">
 <a href="../../staff/{{ staff_member.kebab_case }}">
-  <div class="col span_3 center staff-nav">
-    <img class="{{ staff_member.kebab_case }}-small" src="../../public/staff-headshots/bw/{{ staff_member.kebab_case }}.jpg" alt="{{ staff_member.title_case }}">
-    <h6>{{ staff_member.title_case }}</h6>
-  </div>
+<img class="{{ staff_member.kebab_case }}-small"
+     src="../../public/staff-headshots/bw/{{ staff_member.kebab_case }}.jpg"
+     alt="{{ staff_member.title_case }}" />
+<h6>{{ staff_member.title_case }}</h6>
 </a>
+</div>
 {% endfor %}
 <!-- endfor -->
 <div class="col span_12">


### PR DESCRIPTION
TODO: write automated test

```
it("should not have unclosed tags" function () {
```

check for visible `</a>`

---

this broke when switching to `kramdown`
possibly because `kramdown` wraps img in paragraph tags
